### PR TITLE
Exclude not only ng but also ngLocale module from sorting

### DIFF
--- a/lib/sort.js
+++ b/lib/sort.js
@@ -37,7 +37,7 @@ module.exports = function (files, log, config) {
 			// Store references to each file with a declaration:
 			Object.keys(deps.modules).forEach(function (name) {
 				moduleFiles[name] = file;
-				if (name !== ANGULAR_MODULE) {
+				if (name !== ANGULAR_MODULE && name !== 'ngLocale') {
 					willBeSorted = true;
 				}
 			});

--- a/test/fixture/definesNg.js
+++ b/test/fixture/definesNg.js
@@ -1,0 +1,1 @@
+angular.module('ng', ['ngLocale']);

--- a/test/fixture/definesNgLocale.js
+++ b/test/fixture/definesNgLocale.js
@@ -1,0 +1,1 @@
+angular.module('ngLocale', []);

--- a/test/spec.js
+++ b/test/spec.js
@@ -96,6 +96,22 @@ describe('karma-angular-filesort', function () {
 		}, done);
 	});
 
+	it('should not reorder ng and ngLocale (Angular own) modules', function (done) {
+		sortFiles(emitter, logger, __dirname);
+		emitFiles(['unrelated1.js', 'unrelated2.js', 'dependsOnA.js', 'definesA.js', 'definesNg.js', 'unrelated3.js', 'unrelated4.js', 'definesNgLocale.js']);
+		expect(emit).to.have.been.calledWith('file_list_modified', sinon.match.any);
+		verifyPromise(emit.args[0][1], function (files) {
+			expect(files.included[0].path).to.match(/unrelated1\.js$/);
+			expect(files.included[1].path).to.match(/unrelated2\.js$/);
+			expect(files.included[2].path).to.match(/definesA\.js$/);
+			expect(files.included[3].path).to.match(/dependsOnA\.js$/);
+			expect(files.included[4].path).to.match(/definesNg\.js$/);
+			expect(files.included[5].path).to.match(/unrelated3\.js$/);
+			expect(files.included[6].path).to.match(/unrelated4\.js$/);
+			expect(files.included[7].path).to.match(/definesNgLocale\.js$/);
+		}, done);
+	});
+
 	it('should allow a whitelist to restrict which files are reordered', function (done) {
 		sortFiles(emitter, logger, __dirname, {whitelist: ['fixture/definesA.js', 'fixture/dependsOnA.js']});
 		emitFiles(['definesB.js', 'unrelated1.js', 'dependsOnA.js', 'definesA.js']);


### PR DESCRIPTION
Starting Angular 1.4.4 not ignoring ngLocale will break the sorting. The
change on Angular side that affected this: 70ce425
