### PR TITLE
Fix for issue #4 of "karma-angular-filesort"

### DIFF
--- a/lib/sort.js
+++ b/lib/sort.js
@@ -108,7 +108,7 @@ function isDependecyUsedInAnyDeclaration (dependency, ngDeps) {
 	if (dependency in ngDeps.modules) {
 		return true;
 	}
-	return Object.keys(ngDeps.modules).any(function (module) {
+	return Object.keys(ngDeps.modules).some(function (module) {
 		return ngDeps.modules[module].indexOf(dependency) > -1;
 	});
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "minimatch": "^1.0.0",
-    "ng-dependencies": "^0.1.2",
+    "ng-dependencies": "^0.3.0",
     "q": "^1.0.1",
     "toposort": "^0.2.10"
   },


### PR DESCRIPTION
Turns out that "ng-dependencies" dependency version 0.1.2 uses Sugar;
this library extends native JavaScript objects with additional methods.

Somehow the existence of Sugar stopped the Babel processor from workung

The solution was simple... to upgrade to the latest version of "ng-dependencies" that no longer uses Sugar.
Finally I also had to fix the usage of the Array#any method in "sort.js" since this method isn't
actually a native method but a method added by Sugar; to fix this I changed the code to use Array#some.
